### PR TITLE
Added comments on assumptions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:a18ba9987556eec2e48354848a3c9fb4d5b69ac8
+      - image: trussworks/circleci-docker-primary:7101c99d78352e30245d8276953297308c491bbd
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Configures IAM policy to enforce MFA when accessing the AWS API.
 
+This configured policy also requires users to assume a role for most API calls.
+
 Creates the following resources:
 
 * IAM policy requiring a valid MFA security token for all API calls except those needed for managing a user's own IAM user.

--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,8 @@ data "aws_iam_policy_document" "main" {
     # that do not support MFA, such as sts:GetFederationToken.
     # Therefore, this policy effectively forbids directly calling AWS APIs
     # without assuming a role first.
-    sid    = "BlockMostAccessUnlessSignedInWithMFA"
+    sid = "BlockMostAccessUnlessSignedInWithMFA"
+
     effect = "Deny"
 
     # not_actions is a list of actions that this statement does not apply to.

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,8 @@
 /**
  * Configures IAM policy to enforce MFA when accessing the AWS API.
  *
+ * This configured policy also requires users to assume a role for most API calls.
+ *
  * Creates the following resources:
  *
  * * IAM policy requiring a valid MFA security token for all API calls except those needed for managing a user's own IAM user.
@@ -111,9 +113,15 @@ data "aws_iam_policy_document" "main" {
   }
 
   statement {
+    # Since this statement uses not_actions, it effectively blocks some statements
+    # that do not support MFA, such as sts:GetFederationToken.
+    # Therefore, this policy effectively forbids directly calling AWS APIs
+    # without assuming a role first.
     sid    = "BlockMostAccessUnlessSignedInWithMFA"
     effect = "Deny"
 
+    # not_actions is a list of actions that this statement does not apply to.
+    # Used to apply a policy statement to all actions except those listed.
     not_actions = [
       "iam:ChangePassword",
       "iam:CreateLoginProfile",


### PR DESCRIPTION
The configured policy requires users to assume a role before most API calls.  This PR adds comments to that affect.

If we add a flag to support direct AWS API calls then we can remove the comments; however, I would not suggest it is a priority.