### PR TITLE
Mdawn pin aws providers for terratests 174129036

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ module "aws_mfa" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
+| aws | ~> 2.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.70 |
 
 ## Inputs
 

--- a/examples/simple/providers.tf
+++ b/examples/simple/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  version = "~> 2.70"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,7 @@
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = "~> 2.70"
+  }
 }


### PR DESCRIPTION
# [Pin aws providers for terratests](https://www.pivotaltracker.com/story/show/174129036)

Changes proposed in this pull request:

- Adds `providers.tf` files to terratest folders
- Pins the version for the provider in the top-level versions file

this is just a placeholder test but I did the thing anyway