### PR TITLE
Allow password change without mfa by enabling iam:GetLoginProfile

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,7 @@ data "aws_iam_policy_document" "main" {
       "iam:ListServiceSpecificCredentials",
       "iam:ListMFADevices",
       "iam:GetAccountSummary",
+      "iam:GetLoginProfile",
       "sts:GetSessionToken",
     ]
 


### PR DESCRIPTION
Users without an MFA who have just received an account with password access (not access keys) may need to change their password on first login. Unfortunately the policy doesn't allow them to see their LoginProfile and modify the password. By adding `iam:GetLoginProfile` to the set of actions that are still available without an MFA enabled we can allow folks to modify their password BEFORE having the MFA in place.