### PR TITLE
Fix: Error: Invalid version constraint from terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ module "aws_mfa" {
 
 | Name | Version |
 |------|---------|
-| terraform | => 0.13.0 |
-| aws | => 3 |
+| terraform | >= 0.13.0 |
+| aws | >= 3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | => 3 |
+| aws | >= 3 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "=> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "=> 3"
+      version = ">= 3"
     }
   }
 }


### PR DESCRIPTION
Fixes issue with version constraints

```
The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Invalid version constraint

  on .terraform/modules/mfa/versions.tf line 2, in terraform:
   2:   required_version = "=> 0.13.0"

This string does not use correct version constraint syntax.


Error: Invalid version constraint

  on .terraform/modules/mfa/versions.tf line 5, in terraform:
   5:     aws = {
   6:       source  = "hashicorp/aws"
   7:       version = "=> 3"
   8:     }

This string does not use correct version constraint syntax.
```
