### PR TITLE
fix: mfa resource name should be * as this is not set to username if …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,6 @@ data "aws_iam_policy_document" "main" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:iam::*:mfa/*",
       "arn:${data.aws_partition.current.partition}:iam::*:user/&{aws:username}",
     ]
 

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ data "aws_iam_policy_document" "main" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:iam::*:mfa/&{aws:username}",
+      "arn:${data.aws_partition.current.partition}:iam::*:mfa/*",
       "arn:${data.aws_partition.current.partition}:iam::*:user/&{aws:username}",
     ]
   }
@@ -104,7 +104,7 @@ data "aws_iam_policy_document" "main" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:iam::*:mfa/&{aws:username}",
+      "arn:${data.aws_partition.current.partition}:iam::*:mfa/*",
       "arn:${data.aws_partition.current.partition}:iam::*:user/&{aws:username}",
     ]
 


### PR DESCRIPTION
Users could not create their own virtual MFA devices in the console due to hard coding the MFA permissions to a specific MFA key name. This fixes that issue. 
